### PR TITLE
LoadBalancer component

### DIFF
--- a/edit/networking.istio.io.destinationrule/LoadBalancer.vue
+++ b/edit/networking.istio.io.destinationrule/LoadBalancer.vue
@@ -1,0 +1,181 @@
+<script>
+import LabeledSelect from '@/components/form/LabeledSelect';
+import LabeledInput from '@/components/form/LabeledInput';
+import RadioGroup from '@/components/form/RadioGroup';
+import { get } from '@/utils/object';
+
+export default {
+
+  components: {
+    RadioGroup,
+    LabeledSelect,
+    LabeledInput
+  },
+
+  props: {
+    mode: {
+      type:    String,
+      default: 'edit'
+    },
+
+    // destinationrule.spec.trafficPolicy.loadBalancer
+    value: {
+      type:     Object,
+      default: () => {}
+    }
+  },
+
+  data() {
+    // attempt to initialize useSimple and hashMode off existing properties so the right radio opts are selected when mode=edit
+    const useSimple = !!this.value.simple;
+    let hashMode;
+
+    if (!!get(this.value, 'consistentHash.httpHeaderName')) {
+      hashMode = 'useHeader';
+    } else if (!!get(this.value, 'consistentHash.httpCookie')) {
+      hashMode = 'useCookie';
+    } else if (!!get(this.value, 'consistentHash.useSourceIp')) {
+      hashMode = 'useIP';
+    }
+
+    return {
+      useSimple,
+      hashMode,
+
+      simpleOptions: ['ROUND_ROBIN', 'LEAST_CONN', 'RANDOM', 'PASSTHROUGH'],
+      modeOptions:   [
+        {
+          label: 'Use standard load balancing algorithms',
+          value: true
+        }, {
+          label: 'Use consistent hash-based load balancing for soft session affinity',
+          value: false
+        },
+      ],
+      hashModeOptions: [
+        {
+          label: 'Hash based on specific HTTP header',
+          value: 'useHeader'
+        },
+        {
+          label: 'Hash based on HTTP cookie',
+          value: 'useCookie'
+        },
+        {
+          label: 'Hash based on the source IP address',
+          value: 'useIp'
+        }
+      ],
+    };
+  },
+
+  watch: {
+    useSimple(neu) {
+      if (neu) {
+        delete this.value.consistentHash;
+        this.value.simple = this.simpleOptions[0];
+      } else {
+        delete this.value.simple;
+        this.$set(this.value, 'consistentHash', { minimumRingSize: 1024 });
+        // set hashMode here to trigger watcher and initialize relevant object props
+        this.hashMode = 'useHeader';
+      }
+    },
+
+    hashMode(neu) {
+      switch (neu) {
+      case 'useHeader':
+        delete this.value.consistentHash.httpCookie;
+        delete this.value.consistentHash.useSourceIp;
+        this.$set(this.value.consistentHash, 'httpHeaderName', '');
+        break;
+      case 'useCookie':
+        delete this.value.consistentHash.httpHeaderName;
+        this.$set(this.value.consistentHash, 'httpCookie', {});
+        break;
+      default:
+        delete this.value.consistentHash.httpCookie;
+        delete this.value.consistentHash.httpHeaderName;
+        this.$set(this.value.consistentHash, 'useSourceIp', true);
+        break;
+      }
+    }
+  }
+};
+</script>
+
+<template>
+  <div>
+    <div class="row">
+      <RadioGroup
+        v-model="useSimple"
+        name="loadBalancer"
+        :mode="mode"
+        :options="modeOptions"
+      />
+    </div>
+    <div v-if="useSimple" class="row">
+      <div class="col span-6">
+        <LabeledSelect
+          v-model="value.simple"
+          :options="simpleOptions"
+          label="Algorithm"
+          :mode="mode"
+        />
+      </div>
+    </div>
+    <template v-else>
+      <div class="row mt-20">
+        <div class="col span-6">
+          <RadioGroup
+            v-model="hashMode"
+            name="HashOptions"
+            :mode="mode"
+            :options="hashModeOptions"
+            label="Hash Mode"
+          />
+        </div>
+      </div>
+      <div class="row mb-20">
+        <div class="col span-6">
+          <LabeledInput v-model="value.consistentHash.minimumRingSize" label="Minimum Ring Size" type="number" />
+        </div>
+      </div>
+      <div v-if="hashMode === 'useHeader'" class="row">
+        <div class="col span-6">
+          <LabeledInput
+            v-model="value.consistentHash.httpHeaderName"
+            label="HTTP Header Name"
+            placeholder="e.g. end-user"
+          />
+        </div>
+      </div>
+
+      <div v-if="hashMode === 'useCookie'" class="row">
+        <div class="col span-4">
+          <LabeledInput
+            v-model="value.consistentHash.httpCookie.name"
+            label="Cookie Name"
+            placeholder="e.g. username"
+            required
+          />
+        </div>
+        <div class="col span-4">
+          <LabeledInput
+            v-model="value.consistentHash.httpCookie.path"
+            label="Cookie Path"
+            placeholder="e.g. /"
+          />
+        </div>
+        <div class="col span-4">
+          <LabeledInput
+            v-model="value.consistentHash.httpCookie.ttl"
+            label="TTL"
+            placeholder="e.g. 0s"
+            required
+          />
+        </div>
+      </div>
+    </template>
+  </div>
+</template>

--- a/edit/networking.istio.io.destinationrule/index.vue
+++ b/edit/networking.istio.io.destinationrule/index.vue
@@ -3,95 +3,25 @@ import NameNsDescription from '@/components/form/NameNsDescription';
 import CreateEditView from '@/mixins/create-edit-view';
 import CruResource from '@/components/CruResource';
 import LabeledInput from '@/components/form/LabeledInput';
-import LabeledSelect from '@/components/form/LabeledSelect';
 import Tab from '@/components/Tabbed/Tab';
 import Tabbed from '@/components/Tabbed';
 import KeyValue from '@/components/form/KeyValue';
-import RadioGroup from '@/components/form/RadioGroup';
 import ArrayListGrouped from '@/components/form/ArrayListGrouped';
+import LoadBalancer from './LoadBalancer';
 
 export default {
   components: {
-    CruResource, NameNsDescription, LabeledInput, LabeledSelect, Tab, Tabbed, KeyValue, RadioGroup, ArrayListGrouped,
+    CruResource,
+    NameNsDescription,
+    LabeledInput,
+    Tab,
+    Tabbed,
+    KeyValue,
+    ArrayListGrouped,
+    LoadBalancer
   },
+
   mixins: [CreateEditView],
-  data() {
-    return {
-
-      useSimple: true,
-
-      simpleOptions: ['ROUND_ROBIN', 'LEAST_CONN', 'RANDOM', 'PASSTHROUGH'],
-
-      hashMode: 'useHeader',
-
-      hashOptions: [
-        {
-          label: 'Hash based on specific HTTP header',
-          value: 'useHeader'
-        },
-        {
-          label: 'Hash based on HTTP cookie',
-          value: 'useCookie'
-        },
-        {
-          label: 'Hash based on the source IP address',
-          value: 'useIp'
-        }
-      ],
-
-      radioOptions: [
-        {
-          label: 'Use standard load balancing algorithms',
-          value: true
-        }, {
-          label: 'Use consistent hash-based load balancing for soft session affinity',
-          value: false
-        },
-
-      ]
-    };
-  },
-  watch: {
-    useSimple(neu, old) {
-      if (neu === true) {
-        this.value.spec.trafficPolicy.loadBalancer.simple = 'ROUND_ROBIN';
-        delete this.value.spec.trafficPolicy.loadBalancer.consistentHash;
-      } else {
-        delete this.value.spec.trafficPolicy.loadBalancer.simple;
-        this.value.spec.trafficPolicy.loadBalancer.consistentHash = {};
-      }
-    },
-
-  },
-  methods: {
-    updateHashMode(neu) {
-      if (neu === 'useCookie') {
-        delete this.value.spec.trafficPolicy.loadBalancer.consistentHash.httpHeaderName;
-        this.$set(
-          this.value.spec.trafficPolicy.loadBalancer.consistentHash,
-          'httpCookie',
-          {
-            name: '',
-            path: '',
-            ttl:  ''
-
-          }
-        );
-      }
-
-      // if (neu === 'httpCookie') {
-      //   delete this.value.spec.trafficPolicy.loadBalancer.consistentHash.httpHeaderName;
-      //   this.value.spec.trafficPolicy.loadBalancer.consistentHash.httpCookie = {};
-      // }
-
-      // if (neu === 'httpCookie') {
-      //   delete this.value.spec.trafficPolicy.loadBalancer.consistentHash.httpHeaderName;
-      //   this.value.spec.trafficPolicy.loadBalancer.consistentHash.httpCookie = {};
-      // }
-      this.hashMode = neu;
-    }
-  },
-
 };
 </script>
 
@@ -162,74 +92,7 @@ export default {
           :label="t('istio.destinationRule.loadBalancer.label')"
           :weight="3"
         >
-          <RadioGroup
-            v-model="useSimple"
-            name="loadBalancer"
-            :mode="mode"
-            :options="radioOptions"
-          />
-          <div>
-            <div v-if="useSimple">
-              <LabeledSelect
-
-                v-model="value.spec.trafficPolicy.loadBalancer.simple"
-                :options="simpleOptions"
-                label="Algorithm"
-                :mode="mode"
-              >
-              </LabeledSelect>
-            </div>
-
-            <div v-else class="mt-20">
-              <RadioGroup
-                :value="hashMode"
-                name="Hash Options"
-                :mode="mode"
-                :options="hashOptions"
-                label="Hash Mode"
-                @input="updateHashMode"
-              />
-
-              <div v-if="hashMode === 'useCookie'">
-                <LabeledInput
-                  :value="value.spec.trafficPolicy.loadBalancer.consistentHash.httpCookie.name"
-                  label="Name"
-                  @input="e => $set(value.spec.trafficPolicy.loadBalancer.consistentHash.httpCookie, 'name', e)"
-                >
-                </LabeledInput>
-                <LabeledInput
-                  :value="value.spec.trafficPolicy.loadBalancer.consistentHash.httpCookie.path"
-                  label="Path"
-                  @input="e => $set(value.spec.trafficPolicy.loadBalancer.consistentHash.httpCookie, 'path', e)"
-                >
-                </LabeledInput>
-                <LabeledInput
-                  :value="value.spec.trafficPolicy.loadBalancer.consistentHash.httpCookie.ttl"
-                  label="TTL"
-                  @input="e => $set(value.spec.trafficPolicy.loadBalancer.consistentHash.httpCookie, 'ttl', e)"
-                >
-                </LabeledInput>
-              </div>
-
-              <div v-if="hashMode === 'useHeader'">
-                <LabeledInput>
-                </LabeledInput>
-                <LabeledInput>
-                </LabeledInput>
-                <LabeledInput>
-                </LabeledInput>
-              </div>
-
-              <div v-if="hashMode === 'useIp'">
-                <LabeledInput>
-                </LabeledInput>
-                <LabeledInput>
-                </LabeledInput>
-                <LabeledInput>
-                </LabeledInput>
-              </div>
-            </div>
-          </div>
+          <LoadBalancer v-model="value.spec.trafficPolicy.loadBalancer" :mode="mode" />
         </Tab>
         <Tab
           name="connection-pool"


### PR DESCRIPTION
This PR moves the LoadBalancer logic into its own component. Seems to work for creating destination rules but that should be verified by a second set of eyes as it is an elaborate resource. Things to think about still:
- which of these fields are required? How does the page load when editing a destination rule missing non-required fields like `trafficPolicy`? `applyDefaults` will not run on edit
- `httpCookie.ttl` is an unusual format (https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#duration); is there a better input component to use? Can we add helper text?
- loadbalancer layout currently sux, can we make it less ugly?